### PR TITLE
Lab 8

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -3,9 +3,13 @@ package ru.quipy.apigateway
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
+import java.time.Duration
 import java.util.*
 
 @RestController
@@ -18,6 +22,12 @@ class APIController {
 
     @Autowired
     private lateinit var orderPayer: OrderPayer
+
+//    private val leakingBucketRateLimiter = LeakingBucketRateLimiter(
+//        120,
+//        Duration.ofSeconds(1),
+//        2000
+//    )
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -55,16 +65,17 @@ class APIController {
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): PaymentSubmissionDto {
+    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<PaymentSubmissionDto> {
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-
+ //       if (!leakingBucketRateLimiter.tick())
+//            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build()
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
-        return PaymentSubmissionDto(createdAt, paymentId)
+        return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
     }
 
     class PaymentSubmissionDto(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -27,8 +27,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-7
+payment.accounts=acc-9
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
Было
<img width="1280" height="602" alt="image" src="https://github.com/user-attachments/assets/6de44ae7-90fa-4524-b888-86096fb20ae7" />
Нам на вход поступает 100 rps, запрос выполняется полсекунды и максимум параллельных запросов - 50 (то есть сервер готов обрабатывать 100 rps). Однако вызовы к внешнему сервису являются блокирующими, то есть потоки, делающие вызов, все время запроса ждут ответ, то есть фактически выполняется x * (1 / avgProcessingTime) запросов в секунду при x потоках.
Увеличим число потоков и увидим прекрасную картину:
<img width="1280" height="543" alt="image" src="https://github.com/user-attachments/assets/2e5bc88c-0130-49d8-8c06-7dbbb5fc5c59" />
<img width="1280" height="554" alt="image" src="https://github.com/user-attachments/assets/e2d9df62-24bc-406f-b9d4-61161c1bdb6f" />
