### PR TITLE
Lab 9

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -71,7 +71,7 @@ class APIController {
         }
         catch(ex: Exception) {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", 5.toString())
+                .header("Retry-After", 10.toString())
                 .build()
         }
     }

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -71,7 +71,7 @@ class APIController {
         }
         catch(ex: Exception) {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", 1.toString())
+                .header("Retry-After", 5.toString())
                 .build()
         }
     }

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -71,7 +71,7 @@ class APIController {
         }
         catch(ex: Exception) {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", 10.toString())
+                .header("Retry-After", 1.toString())
                 .build()
         }
     }

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -3,6 +3,8 @@ package ru.quipy.apigateway
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
@@ -55,7 +57,7 @@ class APIController {
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): PaymentSubmissionDto {
+    suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<PaymentSubmissionDto> {
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
@@ -63,8 +65,15 @@ class APIController {
         } ?: throw IllegalArgumentException("No such order $orderId")
 
 
-        val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
-        return PaymentSubmissionDto(createdAt, paymentId)
+        try {
+            val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
+            return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
+        }
+        catch(ex: Exception) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", 1.toString())
+                .build()
+        }
     }
 
     class PaymentSubmissionDto(

--- a/src/main/kotlin/ru/quipy/common/utils/ConcurrentRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/ConcurrentRateLimiter.kt
@@ -1,0 +1,50 @@
+package ru.quipy.common.utils
+
+import kotlinx.coroutines.delay
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicLong
+
+class ConcurrentRateLimiter(
+    private val rate: Long,
+    private val window: Duration,
+) {
+    private val queue = ConcurrentLinkedQueue<Long>()
+    private val sum = AtomicLong(0)
+
+    suspend fun tryTick(deadline: Long): Boolean {
+        while (System.currentTimeMillis() < deadline) {
+            deleteOldTimes()
+            if (sum.get() < rate) {
+                if (tryAdd(System.currentTimeMillis())) {
+                    return true
+                }
+            }
+            delay(10)
+        }
+        return false
+    }
+
+    private fun tryAdd(timeToAdd: Long): Boolean {
+        if (sum.incrementAndGet() <= rate) {
+            queue.add(timeToAdd)
+            return true
+        } else {
+            sum.decrementAndGet()
+            return false
+        }
+    }
+
+    private fun deleteOldTimes() {
+        val leftIntervalTime = System.currentTimeMillis() - window.toMillis()
+        while (true) {
+            val peekTime = queue.peek() ?: break
+            if (peekTime < leftIntervalTime) {
+                queue.poll()
+                sum.decrementAndGet()
+            } else {
+                break
+            }
+        }
+    }
+}

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -35,7 +35,7 @@ class SlidingWindowRateLimiter(
 
     fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(2)
+            Thread.sleep(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -7,12 +7,9 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 class SlidingWindowRateLimiter(
     private val rate: Long,
@@ -21,7 +18,7 @@ class SlidingWindowRateLimiter(
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
     private val sum = AtomicLong(0)
-    private val queue = ConcurrentLinkedQueue<Measure>()
+    private val queue = PriorityBlockingQueue<Measure>(10_000)
 
     override fun tick(): Boolean {
         while (true) {
@@ -62,7 +59,7 @@ class SlidingWindowRateLimiter(
                 continue
             }
             sum.addAndGet(-1)
-            queue.take(1)
+            queue.take()
         }
     }.invokeOnCompletion { th -> if (th != null) logger.error("Rate limiter release job completed", th) }
     companion object {

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -33,9 +33,9 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    suspend fun tickBlocking() {
+    fun tickBlocking() {
         while (!tick()) {
-            delay(10)
+            Thread.sleep(2)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -33,9 +33,9 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    suspend fun tickBlocking() {
+    fun tickBlocking() {
         while (!tick()) {
-            delay(10)
+            Thread.sleep(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -33,9 +33,9 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    fun tickBlocking() {
+    suspend fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(10)
+            delay(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
@@ -20,7 +21,7 @@ class SlidingWindowRateLimiter(
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
     private val sum = AtomicLong(0)
-    private val queue = PriorityBlockingQueue<Measure>(10_000)
+    private val queue = ConcurrentLinkedQueue<Measure>()
 
     override fun tick(): Boolean {
         while (true) {
@@ -61,7 +62,7 @@ class SlidingWindowRateLimiter(
                 continue
             }
             sum.addAndGet(-1)
-            queue.take()
+            queue.take(1)
         }
     }.invokeOnCompletion { th -> if (th != null) logger.error("Rate limiter release job completed", th) }
     companion object {

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -33,9 +33,9 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    fun tickBlocking() {
+    suspend fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(2)
+            delay(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -35,7 +35,7 @@ class SlidingWindowRateLimiter(
 
     fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(10)
+            Thread.sleep(2)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -31,10 +31,10 @@ class OrderPayer {
 
     private val paymentExecutor = ThreadPoolExecutor(
         100,
-        1500,
+        1200,
         70L,
         TimeUnit.SECONDS,
-        LinkedBlockingQueue(11_000),
+        LinkedBlockingQueue(12_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,8 +30,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        150,
-        1200,
+        100,
+        1700,
         70L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(11_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -31,7 +31,7 @@ class OrderPayer {
 
     private val paymentExecutor = ThreadPoolExecutor(
         100,
-        1100,
+        1500,
         70L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(8_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,8 +30,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        100,
-        1200,
+        200,
+        300,
         70L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(11_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,11 +30,11 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        100,
+        150,
         1200,
         70L,
         TimeUnit.SECONDS,
-        LinkedBlockingQueue(12_000),
+        LinkedBlockingQueue(11_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,7 +30,7 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        300,
+        500,
         1200,
         70L,
         TimeUnit.SECONDS,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -31,7 +31,7 @@ class OrderPayer {
 
     private val paymentExecutor = ThreadPoolExecutor(
         100,
-        1700,
+        1200,
         70L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(11_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -31,8 +31,8 @@ class OrderPayer {
 
     private val paymentExecutor = ThreadPoolExecutor(
         200,
-        300,
-        0L,
+        500,
+        10L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(11_000),
         NamedThreadFactory("payment-submission-executor"),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,7 +30,7 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        500,
+        100,
         1200,
         70L,
         TimeUnit.SECONDS,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -34,7 +34,7 @@ class OrderPayer {
         1500,
         70L,
         TimeUnit.SECONDS,
-        LinkedBlockingQueue(8_000),
+        LinkedBlockingQueue(11_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -1,5 +1,8 @@
 package ru.quipy.payments.logic
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,18 +30,20 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
-        0L,
-        TimeUnit.MILLISECONDS,
+        100,
+        1100,
+        70L,
+        TimeUnit.SECONDS,
         LinkedBlockingQueue(8_000),
         NamedThreadFactory("payment-submission-executor"),
         CallerBlockingRejectedExecutionHandler()
     )
 
-    fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+    val executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher())
+
+    suspend fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        paymentExecutor.submit {
+        executorScope.launch {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -30,7 +30,7 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        100,
+        300,
         1200,
         70L,
         TimeUnit.SECONDS,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -32,7 +32,7 @@ class OrderPayer {
     private val paymentExecutor = ThreadPoolExecutor(
         200,
         300,
-        70L,
+        0L,
         TimeUnit.SECONDS,
         LinkedBlockingQueue(11_000),
         NamedThreadFactory("payment-submission-executor"),

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,7 +7,6 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.OngoingWindow
@@ -75,8 +74,7 @@ class PaymentExternalSystemAdapterImpl(
 
         val transactionId = UUID.randomUUID()
 
-        if (rateLimiter.tick())
-            delay(10)
+        rateLimiter.tickBlocking()
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
         paymentESService.update(paymentId) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -74,6 +74,7 @@ class PaymentExternalSystemAdapterImpl(
 
         val transactionId = UUID.randomUUID()
 
+        rateLimiter.tickBlocking()
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
         paymentESService.update(paymentId) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -93,7 +93,14 @@ class PaymentExternalSystemAdapterImpl(
     ) {
         var x = 0
         var shouldTry = true
+
         while (shouldTry) {
+            if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                }
+                return
+            }
             shouldTry = false
             x++
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -106,22 +106,10 @@ class PaymentExternalSystemAdapterImpl(
 
             while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail) {
                 delay(10)
-                if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
-                    }
-                    return
-                }
             }
 
             while (!rateLimiter.tick()) {
                 delay(10)
-                if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
-                    }
-                    return
-                }
             }
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -55,16 +55,8 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentileHistogram()
         .register(meterRegistry)
 
-    //private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
     private val ongoingWindow = NonBlockingOngoingWindow(parallelRequests)
-
-    private val rateLimiter = RateLimiter.of(
-        "payment-rate-limiter",
-        RateLimiterConfig.custom()
-            .limitForPeriod(rateLimitPerSec.toInt())
-            .limitRefreshPeriod(Duration.ofSeconds(1))
-            .timeoutDuration(Duration.ZERO)
-            .build())
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -118,10 +110,16 @@ class PaymentExternalSystemAdapterImpl(
                 delay(10)
             }
 
-            try {
-                while (!rateLimiter.acquirePermission()) {
-                    delay(10)
+            while (!rateLimiter.tick()) {
+                delay(10)
+            }
+            if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
                 }
+                return
+            }
+            try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {
                         mapper.readValue(response.body(), ExternalSysResponse::class.java)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -93,13 +93,14 @@ class PaymentExternalSystemAdapterImpl(
     ) {
         var x = 0
         var shouldTry = true
-        try {
-            while(ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
+        while (shouldTry) {
+            shouldTry = false
+            x++
+
+            while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
                 delay(10)
             rateLimiter.tickBlocking();
-            while (shouldTry) {
-                shouldTry = false
-                x++
+            try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {
                         mapper.readValue(response.body(), ExternalSysResponse::class.java)
@@ -118,13 +119,12 @@ class PaymentExternalSystemAdapterImpl(
                         shouldTry = true
                     }
                 }
-                if (shouldTry)
-                    delay(100 * x.toLong())
+            } finally {
+                ongoingWindow.releaseWindow()
             }
-        } finally {
-            ongoingWindow.releaseWindow()
+            if (shouldTry)
+                delay(100 * x.toLong())
         }
-
     }
 }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.ConcurrentRateLimiter
 import ru.quipy.common.utils.NonBlockingOngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
@@ -55,7 +56,7 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentileHistogram()
         .register(meterRegistry)
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
+    private val rateLimiter = ConcurrentRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
     private val ongoingWindow = NonBlockingOngoingWindow(parallelRequests)
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -110,15 +111,13 @@ class PaymentExternalSystemAdapterImpl(
                 delay(10)
             }
 
-            while (!rateLimiter.tick()) {
-                delay(10)
-            }
-            if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
+            if (!rateLimiter.tryTick(deadline)) {
                 paymentESService.update(paymentId) {
                     it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
                 }
                 return
             }
+
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {
@@ -134,7 +133,7 @@ class PaymentExternalSystemAdapterImpl(
                     paymentESService.update(paymentId) {
                         it.logProcessing(body.result, now(), transactionId, reason = body.message)
                     }
-                    if (!body.result) {
+                    if (!body.result && x < retryCount) {
                         shouldTry = true
                     }
                 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val parallelRequests = properties.parallelRequests
 
     private val httpClient = HttpClient.newBuilder()
-        .executor(Executors.newFixedThreadPool(100))
+        .executor(Executors.newFixedThreadPool(110))
         .version(HttpClient.Version.HTTP_2)
         .build()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -46,7 +46,7 @@ class PaymentExternalSystemAdapterImpl(
     private val parallelRequests = properties.parallelRequests
 
     private val httpClient = HttpClient.newBuilder()
-        .executor(Executors.newFixedThreadPool(110))
+        .executor(Executors.newFixedThreadPool(100))
         .version(HttpClient.Version.HTTP_2)
         .build()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -97,11 +97,7 @@ class PaymentExternalSystemAdapterImpl(
 
         while (shouldTry) {
             if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
-                with(Dispatchers.IO) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
-                    }
-                }
+                logResult(paymentId, transactionId, "Deadline exceeded")
                 return
             }
             shouldTry = false
@@ -147,12 +143,20 @@ class PaymentExternalSystemAdapterImpl(
                     delay(100 * x.toLong())
             } catch (e: Exception) {
                 logger.error("[$accountName] Payment failed for $paymentId", e)
-                with(Dispatchers.IO) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
+                logResult(paymentId, transactionId, e.message)
+            }
+        }
+    }
+
+    private fun logResult(paymentId: UUID, transactionId: UUID, message: String?) {
+        try {
+            with(Dispatchers.IO) {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = message)
                 }
             }
+        } catch(e: Exception) {
+            logger.error("[$accountName] failed to save result for $paymentId", e)
         }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,6 +2,8 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.delay
@@ -53,8 +55,16 @@ class PaymentExternalSystemAdapterImpl(
         .publishPercentileHistogram()
         .register(meterRegistry)
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
+    //private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
     private val ongoingWindow = NonBlockingOngoingWindow(parallelRequests)
+
+    private val rateLimiter = RateLimiter.of(
+        "payment-rate-limiter",
+        RateLimiterConfig.custom()
+            .limitForPeriod(rateLimitPerSec.toInt())
+            .limitRefreshPeriod(Duration.ofSeconds(1))
+            .timeoutDuration(Duration.ZERO)
+            .build())
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -108,10 +118,10 @@ class PaymentExternalSystemAdapterImpl(
                 delay(10)
             }
 
-            while (!rateLimiter.tick()) {
-                delay(10)
-            }
             try {
+                while (!rateLimiter.acquirePermission()) {
+                    delay(10)
+                }
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {
                         mapper.readValue(response.body(), ExternalSysResponse::class.java)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.NonBlockingOngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -53,6 +54,7 @@ class PaymentExternalSystemAdapterImpl(
         .register(meterRegistry)
 
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
+    private val ongoingWindow = NonBlockingOngoingWindow(parallelRequests)
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -67,16 +69,6 @@ class PaymentExternalSystemAdapterImpl(
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
-        while (!rateLimiter.tick()) {
-            if (now() >= deadline) {
-                paymentESService.update(paymentId) {
-                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
-                }
-                return
-            }
-            delay(10)
-        }
 
         val request = HttpRequest.newBuilder()
             .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
@@ -101,29 +93,36 @@ class PaymentExternalSystemAdapterImpl(
     ) {
         var x = 0
         var shouldTry = true
-        while (shouldTry) {
-            shouldTry = false
-            x++
-            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
-                val body = try {
-                    mapper.readValue(response.body(), ExternalSysResponse::class.java)
-                } catch (e: Exception) {
-                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
-                    ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                }
+        try {
+            while(ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
+                delay(10)
+            rateLimiter.tickBlocking();
+            while (shouldTry) {
+                shouldTry = false
+                x++
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
+                    val body = try {
+                        mapper.readValue(response.body(), ExternalSysResponse::class.java)
+                    } catch (e: Exception) {
+                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                    }
 
-                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                    // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                    // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                    }
+                    if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount) {
+                        shouldTry = true
+                    }
                 }
-                if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount) {
-                    shouldTry = true
-                }
+                if (shouldTry)
+                    delay(100 * x.toLong())
             }
-            if (shouldTry)
-                delay(100 * x.toLong())
+        } finally {
+            ongoingWindow.releaseWindow()
         }
 
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -99,7 +99,8 @@ class PaymentExternalSystemAdapterImpl(
 
             while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
                 delay(10)
-            rateLimiter.tickBlocking();
+            while (!rateLimiter.tick())
+                delay(10)
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {
@@ -123,7 +124,7 @@ class PaymentExternalSystemAdapterImpl(
                 ongoingWindow.releaseWindow()
             }
             if (shouldTry)
-                delay(100 * x.toLong())
+                delay(10 * x.toLong())
         }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.OngoingWindow
@@ -74,7 +75,7 @@ class PaymentExternalSystemAdapterImpl(
 
         val transactionId = UUID.randomUUID()
 
-        rateLimiter.tickBlocking()
+
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
         paymentESService.update(paymentId) {
@@ -82,6 +83,16 @@ class PaymentExternalSystemAdapterImpl(
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
+
+        while (!rateLimiter.tick()) {
+            if (now() >= deadline) {
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                }
+                return
+            }
+            delay(10)
+        }
 
         val request = HttpRequest.newBuilder()
             .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -123,7 +123,7 @@ class PaymentExternalSystemAdapterImpl(
                     paymentESService.update(paymentId) {
                         it.logProcessing(body.result, now(), transactionId, reason = body.message)
                     }
-                    if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount) {
+                    if (!body.result) {
                         shouldTry = true
                     }
                 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,15 +2,11 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -21,7 +17,6 @@ import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingDeque
 
 
 // Advice: always treat time as a Duration
@@ -51,24 +46,13 @@ class PaymentExternalSystemAdapterImpl(
         .version(HttpClient.Version.HTTP_2)
         .build()
 
-    private val responseTimes = LinkedBlockingDeque<Long>(1024)
-
-
     var requestDuration = DistributionSummary.builder("avg_payment_processing_time")
         .description("request_latency")
         .publishPercentiles(0.5, 0.75, 0.9, 0.95, 0.99)
         .publishPercentileHistogram()
         .register(meterRegistry)
 
-
-    private val retryCounter = Counter.builder("retry_count")
-        .description("retry_count")
-        .register(meterRegistry)
-
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
-    private val ongoingWindow = OngoingWindow(parallelRequests)
-
-    private val executorScope = CoroutineScope(Dispatchers.IO)
 
     override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
@@ -141,26 +125,6 @@ class PaymentExternalSystemAdapterImpl(
         }
 
     }
+}
 
-        private fun addResponseTime(durationMs: Long) {
-            if (responseTimes.remainingCapacity() == 0) {
-                responseTimes.pollFirst()
-            }
-
-            responseTimes.offer(durationMs)
-        }
-
-
-        private fun computeQuantile(quantile: Double): Long {
-            val current = responseTimes.toTypedArray()
-            if (current.isEmpty()) {
-                return (requestAverageProcessingTime.toMillis() * quantile).toLong()
-            }
-
-            Arrays.sort(current)
-            val idx = ((current.size - 1) * quantile).toInt()
-            return current[idx].toLong()
-        }
-    }
-
-    public fun now() = System.currentTimeMillis()
+public fun now() = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -107,7 +107,7 @@ class PaymentExternalSystemAdapterImpl(
             while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
                 delay(10)
             while (!rateLimiter.tick())
-                delay(100)
+                Thread.sleep(10)
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -118,10 +118,12 @@ class PaymentExternalSystemAdapterImpl(
                 paymentESService.update(paymentId) {
                     it.logProcessing(body.result, now(), transactionId, reason = body.message)
                 }
-                if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount)
+                if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount) {
                     shouldTry = true
-
+                }
             }
+            if (shouldTry)
+                delay(100 * x.toLong())
         }
 
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,7 @@ import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
@@ -99,8 +100,10 @@ class PaymentExternalSystemAdapterImpl(
 
         while (shouldTry) {
             if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
-                paymentESService.update(paymentId) {
-                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                with(Dispatchers.IO) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                    }
                 }
                 return
             }
@@ -112,36 +115,38 @@ class PaymentExternalSystemAdapterImpl(
             }
 
             if (!rateLimiter.tryTick(deadline)) {
-                paymentESService.update(paymentId) {
-                    it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                with(Dispatchers.IO) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                    }
                 }
                 return
             }
 
-            try {
-                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
-                    val body = try {
-                        mapper.readValue(response.body(), ExternalSysResponse::class.java)
-                    } catch (e: Exception) {
-                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
-                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                    }
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
+                val body = try {
+                    mapper.readValue(response.body(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                } finally {
+                    ongoingWindow.releaseWindow()
+                }
 
-                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-                    // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                    // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                with(Dispatchers.IO) {
                     paymentESService.update(paymentId) {
                         it.logProcessing(body.result, now(), transactionId, reason = body.message)
                     }
-                    if (!body.result && x < retryCount) {
-                        shouldTry = true
-                    }
                 }
-            } finally {
-                ongoingWindow.releaseWindow()
+                if (!body.result && x < retryCount) {
+                    shouldTry = true
+                }
             }
             if (shouldTry)
-                delay(10 * x.toLong())
+                delay(1000 * x.toLong())
         }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -100,7 +100,7 @@ class PaymentExternalSystemAdapterImpl(
             while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
                 delay(10)
             while (!rateLimiter.tick())
-                delay(10)
+                delay(100)
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,8 +2,6 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.github.resilience4j.ratelimiter.RateLimiter
-import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +10,6 @@ import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.ConcurrentRateLimiter
 import ru.quipy.common.utils.NonBlockingOngoingWindow
-import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.URI
@@ -110,43 +107,52 @@ class PaymentExternalSystemAdapterImpl(
             shouldTry = false
             x++
 
-            while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail) {
-                delay(10)
-            }
+            try {
+                while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail) {
+                    delay(10)
+                }
 
-            if (!rateLimiter.tryTick(deadline)) {
-                with(Dispatchers.IO) {
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                if (!rateLimiter.tryTick(deadline)) {
+                    with(Dispatchers.IO) {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                        }
+                    }
+                    return
+                }
+
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
+                    val body = try {
+                        mapper.readValue(response.body(), ExternalSysResponse::class.java)
+                    } catch (e: Exception) {
+                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                    } finally {
+                        ongoingWindow.releaseWindow()
+                    }
+
+                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                    // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                    // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                    with(Dispatchers.IO) {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                        }
+                    }
+                    if (!body.result && x < retryCount) {
+                        shouldTry = true
                     }
                 }
-                return
-            }
-
-            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
-                val body = try {
-                    mapper.readValue(response.body(), ExternalSysResponse::class.java)
-                } catch (e: Exception) {
-                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
-                    ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                } finally {
-                    ongoingWindow.releaseWindow()
-                }
-
-                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                if (shouldTry)
+                    delay(100 * x.toLong())
+            } catch (e: Exception) {
+                logger.error("[$accountName] Payment failed for $paymentId", e)
                 with(Dispatchers.IO) {
                     paymentESService.update(paymentId) {
-                        it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
                     }
                 }
-                if (!body.result && x < retryCount) {
-                    shouldTry = true
-                }
             }
-            if (shouldTry)
-                delay(1000 * x.toLong())
         }
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -104,10 +104,25 @@ class PaymentExternalSystemAdapterImpl(
             shouldTry = false
             x++
 
-            while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail)
+            while (ongoingWindow.putIntoWindow() is NonBlockingOngoingWindow.WindowResponse.Fail) {
                 delay(10)
-            while (!rateLimiter.tick())
-                Thread.sleep(10)
+                if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                    }
+                    return
+                }
+            }
+
+            while (!rateLimiter.tick()) {
+                delay(10)
+                if (now() + requestAverageProcessingTime.toMillis() >= deadline) {
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Deadline exceeded")
+                    }
+                    return
+                }
+            }
             try {
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
                     val body = try {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.OngoingWindow
@@ -74,7 +75,8 @@ class PaymentExternalSystemAdapterImpl(
 
         val transactionId = UUID.randomUUID()
 
-        rateLimiter.tickBlocking()
+        if (rateLimiter.tick())
+            delay(10)
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
         paymentESService.update(paymentId) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -5,20 +5,22 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
-import io.prometheus.metrics.core.metrics.Summary
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
-import java.io.InterruptedIOException
-import java.net.SocketTimeoutException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingDeque
 
 
 // Advice: always treat time as a Duration
@@ -43,9 +45,13 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec.toLong()
     private val parallelRequests = properties.parallelRequests
 
-    private val client = OkHttpClient.Builder()
-        .callTimeout(1500, TimeUnit.MILLISECONDS)
+    private val httpClient = HttpClient.newBuilder()
+        .executor(Executors.newFixedThreadPool(100))
+        .version(HttpClient.Version.HTTP_2)
         .build()
+
+    private val responseTimes = LinkedBlockingDeque<Long>(1024)
+
 
     var requestDuration = DistributionSummary.builder("avg_payment_processing_time")
         .description("request_latency")
@@ -61,7 +67,9 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec, Duration.ofSeconds(1))
     private val ongoingWindow = OngoingWindow(parallelRequests)
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    private val executorScope = CoroutineScope(Dispatchers.IO)
+
+    override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()
@@ -74,31 +82,12 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        try {
-            val request = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                post(emptyBody)
-            }.build()
+        val request = HttpRequest.newBuilder()
+            .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build()
 
-            sendRequest(request, transactionId, paymentId, retryCount = 3, deadline = deadline)
-        } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                    }
-                }
-
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
-                }
-            }
-        }
+        sendRequest(request, transactionId, paymentId, retryCount = 3, deadline = deadline)
     }
 
     override fun price() = properties.price
@@ -107,8 +96,8 @@ class PaymentExternalSystemAdapterImpl(
 
     override fun name() = properties.accountName
 
-    private fun sendRequest(
-        request: Request,
+    private suspend fun sendRequest(
+        request: HttpRequest,
         transactionId: UUID,
         paymentId: UUID,
         retryCount: Int = 1,
@@ -119,68 +108,47 @@ class PaymentExternalSystemAdapterImpl(
         while (shouldTry) {
             shouldTry = false
             x++
-            rateLimiter.tickBlocking()
-            try {
-                ongoingWindow.acquire()
-
-                var start = now()
-                client.newCall(request).execute().use { response ->
-                    requestDuration.record((now() - start).toDouble())
-                    val body = try {
-                        mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                    } catch (e: Exception) {
-                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                    }
-
-                    logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-                    // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                    // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                    }
-                    if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount)
-                        shouldTry = true
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
+                val body = try {
+                    mapper.readValue(response.body(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
                 }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> {
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                        break
-                    }
 
-                    is InterruptedIOException -> {
-                        if (x < retryCount && deadline - now() > requestAverageProcessingTime.toMillis()) {
-                            shouldTry = true
-                            retryCounter.increment()
-                            ongoingWindow.release()
-                            continue
-                        }
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
-                        break
-                    }
-
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
-                        break
-                    }
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
                 }
-            } finally {
-                ongoingWindow.release()
+                if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis() && x < retryCount)
+                    shouldTry = true
+
             }
         }
-    }
-}
 
-public fun now() = System.currentTimeMillis()
+    }
+
+        private fun addResponseTime(durationMs: Long) {
+            if (responseTimes.remainingCapacity() == 0) {
+                responseTimes.pollFirst()
+            }
+
+            responseTimes.offer(durationMs)
+        }
+
+
+        private fun computeQuantile(quantile: Double): Long {
+            val current = responseTimes.toTypedArray()
+            if (current.isEmpty()) {
+                return (requestAverageProcessingTime.toMillis() * quantile).toLong()
+            }
+
+            Arrays.sort(current)
+            val idx = ((current.size - 1) * quantile).toInt()
+            return current[idx].toLong()
+        }
+    }
+
+    public fun now() = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -7,7 +7,7 @@ interface PaymentService {
     /**
      * Submit payment request to some external service.
      */
-    fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 }
 
 /**
@@ -17,7 +17,7 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 
     fun name(): String
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -1,16 +1,8 @@
 package ru.quipy.payments.logic
 
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import ru.quipy.common.utils.NamedThreadFactory
-import ru.quipy.core.EventSourcingService
-import ru.quipy.payments.api.PaymentAggregate
-import java.time.Duration
 import java.util.*
-import java.util.concurrent.Executors
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 
 @Service
@@ -21,7 +13,7 @@ class PaymentSystemImpl(
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
     }
 
-    override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
             account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=acc-9
+payment.accounts=acc-12
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ event.sourcing.sagas-enabled=false
 spring.datasource.hikari.jdbc-url=jdbc:postgresql://${POSTGRES_ADDRESS:localhost}:${POSTGRES_PORT:65432}/postgres
 spring.datasource.hikari.username=tiny_es
 spring.datasource.hikari.password=tiny_es
+spring.datasource.hikari.minimum-idle=400
 spring.datasource.hikari.leak-detection-threshold=2000
 
 management.metrics.web.server.request.autotime.percentiles=0.95


### PR DESCRIPTION
Было:
<img width="1888" height="890" alt="image" src="https://github.com/user-attachments/assets/4d1d26a7-6aab-4953-a360-1fd4c9b34a30" />

Внешний сервис:
PaymentAccountProperties(serviceName=OopsPerSecond, accountName=acc-12, parallelRequests=20000, rateLimitPerSec=1100, price=30, averageProcessingTime=PT10S, enabled=true)
Входная нагрузка:
"ratePerSecond": 1000,
"testCount": 200000,
"processingTimeMillis": 50000

Наш сервис тормозил обработку запросов: не успевали обрабатывать все входящие запросы даже 50 потоками + был блокирующий HTTP1. 

Стало:
Перешли на мультиплексированнный HTTP2, а также стали использовать асинхронные запросы.
<img width="1280" height="580" alt="image" src="https://github.com/user-attachments/assets/b91b729f-1ed7-4b5a-a059-7ca125c14203" />
